### PR TITLE
Force str at saveAs argument to avoid TypeError from pylokit

### DIFF
--- a/example/invoices/forms.py
+++ b/example/invoices/forms.py
@@ -15,4 +15,8 @@ class InvoiceForm(forms.Form):
     customer = forms.ModelChoiceField(queryset=Customer.objects.all())
     subject = forms.CharField()
     amount = forms.DecimalField()
+    model = forms.CharField(
+        required=False,
+        help_text="Optional. Absolute Path for alternative ODT template."
+    )
     format = forms.ChoiceField(choices=FORMAT_CHOICES)

--- a/example/invoices/views.py
+++ b/example/invoices/views.py
@@ -13,8 +13,9 @@ def invoice_view(request):
 
     if form.is_valid():
         doctype = form.cleaned_data['format']
+        invoice_model = form.cleaned_data['model'] or 'invoices/invoice.odt'
         filename = fill_template(
-            'invoices/invoice.odt', form.cleaned_data,
+            invoice_model, form.cleaned_data,
             output_format=doctype)
         visible_filename = 'invoice.{}'.format(doctype)
 

--- a/templated_docs/__init__.py
+++ b/templated_docs/__init__.py
@@ -131,7 +131,7 @@ def fill_template(template_name, context, output_format='odt'):
             conv_file = NamedTemporaryFile(delete=False,
                                            suffix='.%s' % output_format)
             with lo.documentLoad(str(dest_file.name)) as doc:
-                doc.saveAs(conv_file.name)
+                doc.saveAs(str(conv_file.name))
             os.unlink(dest_file.name)
         return conv_file.name
     else:

--- a/templated_docs/__init__.py
+++ b/templated_docs/__init__.py
@@ -100,7 +100,9 @@ def fill_template(template_name, context, output_format='odt'):
     manifest_data = ''
     for name in source.namelist():
         data = smart_str(source.read(name))
-        if name in ('content.xml', 'styles.xml'):
+        patterns = ['content.xml', 'styles.xml']
+        # check for patterns to allow objects inside doc
+        if any(x in name for x in patterns):
             template = Template(fix_inline_tags(data))
             data = template.render(context)
         elif name == 'META-INF/manifest.xml':

--- a/templated_docs/__init__.py
+++ b/templated_docs/__init__.py
@@ -72,6 +72,9 @@ def find_template_file(template_name):
             path = getattr(origin, 'name', origin)  # Django <1.9 compatibility
             if os.path.exists(path):
                 return path
+    # allow odt templates from absolute path
+    if os.path.exists(template_name):
+        return template_name
     raise TemplateDoesNotExist(template_name)
 
 


### PR DESCRIPTION
For some reason the example provided with the package was giving me TypeError on pylokit saveAs method. Simply forcing the argument as str solved the issue.